### PR TITLE
Issues in docker-compose template and instructions

### DIFF
--- a/administration-guide/installation.md
+++ b/administration-guide/installation.md
@@ -190,7 +190,7 @@ Run the following command to start Semaphore with configured database (MySQL or 
 docker-compose up
 ```
 
-&#x20;Semaphore will be available via the following URL [https://localhost:3000](https://localhost:3000).
+&#x20;Semaphore will be available via the following URL [http://localhost:3000](http://localhost:3000).
 
 For more information about the Docker Compose, see the [Docker Compose reference](https://docs.docker.com/compose/).
 

--- a/administration-guide/installation.md
+++ b/administration-guide/installation.md
@@ -125,8 +125,6 @@ services:
   # uncomment this section and comment out the mysql section to use postgres instead of mysql
   #postgres:
     #restart: unless-stopped
-    #ports:
-      #- 5432:5432
     #image: postgres:14
     #hostname: postgres
     #volumes: 
@@ -138,8 +136,6 @@ services:
   # if you wish to use postgres, comment the mysql service section below 
   mysql:
     restart: unless-stopped
-    ports:
-      - 3306:3306
     image: mysql:8.0
     hostname: mysql
     volumes:


### PR DESCRIPTION
Two suggestions:
- There's no need to publish the database ports.
- after setup, the webserver listens without SSL on port 3000 - so this URL with https:// is wrong