### PR TITLE
Update docker-compose example in installation.md

### DIFF
--- a/administration-guide/installation.md
+++ b/administration-guide/installation.md
@@ -157,7 +157,7 @@ services:
       SEMAPHORE_DB_PASS: semaphore
       SEMAPHORE_DB_HOST: mysql # for postgres, change to: postgres
       SEMAPHORE_DB_PORT: 3306 # change to 5432 for postgres
-      SEMAPHORE_DB_DIALECT: mysql
+      SEMAPHORE_DB_DIALECT: mysql # for postgres, change to: postgres
       SEMAPHORE_DB: semaphore
       SEMAPHORE_PLAYBOOK_PATH: /tmp/semaphore/
       SEMAPHORE_ADMIN_PASSWORD: changeme


### PR DESCRIPTION
Updated docker-compose example to include the necessary change of the SEMAPHORE_DB_DIALECT env variable to be changed to `postgres` when using postgresql.