### PR TITLE
chore: Use correct verb server as opposed to service for semaphore

### DIFF
--- a/administration-guide/installation.md
+++ b/administration-guide/installation.md
@@ -121,7 +121,7 @@ semaphore setup
 Now you can run Semaphore:
 
 ```
-semaphore service --config=./config.json
+semaphore server --config=./config.json
 ```
 
 Semaphore will be available via this URL [https://localhost:3000](https://localhost:3000).
@@ -258,7 +258,7 @@ Expand-Archive -Path semaphore.zip  -DestinationPath ./
 Now you can run Semaphore:
 
 ```
-./semaphore service --config=./config.json
+./semaphore server --config=./config.json
 ```
 
 Semaphore will be available via the following URL [https://localhost:3000](https://localhost:3000).
@@ -288,7 +288,7 @@ After=network-online.target
 [Service]
 Type=simple
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/path/to/semaphore service --config=/path/to/config.json
+ExecStart=/path/to/semaphore server --config=/path/to/config.json
 SyslogIdentifier=semaphore
 Restart=always
 RestartSec=10s

--- a/administration-guide/installation_manually.md
+++ b/administration-guide/installation_manually.md
@@ -252,7 +252,7 @@ ConditionPathExists=/usr/bin/semaphore
 ConditionPathExists=/etc/semaphore/config.json
 
 [Service]
-ExecStart=/usr/bin/semaphore service --config /etc/semaphore/config.json
+ExecStart=/usr/bin/semaphore server --config /etc/semaphore/config.json
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=10s
@@ -296,7 +296,7 @@ ExecStartPre=/bin/bash -c 'source /home/semaphore/venv/bin/activate \
 
 # REPLACE THE EXISTING 'ExecStart'
 ExecStart=/bin/bash -c 'source /home/semaphore/venv/bin/activate \
-                        && /usr/bin/semaphore service --config /etc/semaphore/config.json'
+                        && /usr/bin/semaphore server --config /etc/semaphore/config.json'
 ```
 
 ----
@@ -372,7 +372,7 @@ ExecStartPre=/bin/bash -c 'ansible-galaxy collection install --upgrade -r /home/
 ExecStartPre=/bin/bash -c 'ansible-galaxy role install --force -r /home/semaphore/requirements.yml'
 ExecStartPre=/bin/bash -c 'python3 -m pip install --upgrade --user -r /home/semaphore/requirements.txt'
 
-ExecStart=/usr/bin/semaphore service --config /etc/semaphore/config.json
+ExecStart=/usr/bin/semaphore server --config /etc/semaphore/config.json
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
@@ -403,7 +403,7 @@ ExecStartPre=/bin/bash -c 'source /home/semaphore/venv/bin/activate \
                            && ansible-galaxy role install --force -r /home/semaphore/requirements.yml'
 
 ExecStart=/bin/bash -c 'source /home/semaphore/venv/bin/activate \
-                        && /usr/bin/semaphore service --config /etc/semaphore/config.json'
+                        && /usr/bin/semaphore server --config /etc/semaphore/config.json'
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
According the semaphore --help, there is no command verb service.

$ /usr/bin/semaphore --help
Ansible Semaphore is a beautiful web UI for Ansible.
Source code is available at https://github.com/ansible-semaphore/semaphore.
Complete documentation is available at https://ansible-semaphore.com.

Usage:
  semaphore [flags]
  semaphore [command]

Available Commands:
  completion  generate the autocompletion script for the specified shell
  help        Help about any command
  migrate     Execute migrations
  runner      Run in runner mode
  server      Run in server mode
  setup       Perform interactive setup
  upgrade     Upgrade to latest stable version
  user        Manage users
  vault       Manage access keys and other secrets
  version     Print the version of Semaphore

Flags:
      --config string   Configuration file path
  -h, --help            help for semaphore

Use "semaphore [command] --help" for more information about a command.